### PR TITLE
fix: initialise res.data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function(res, callback) {
-    var data = '';
+    res.data = '';
 
     res.setEncoding('binary');
     res.on('data', function (chunk) {


### PR DESCRIPTION
the local variable `data` was unused and at the same time `res.data` not initialised.
